### PR TITLE
Use open source library instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,54 +1,249 @@
+defaults: &defaults
+  working_directory: ~/project
+  docker:
+    - image: quay.io/haskell_works/stack-build-cabal:18.04
+
+  steps:
+    - checkout
+
+    - run:
+        name: Remove Cabal file
+        command: rm -f *.cabal
+
+    - run:
+        name: Copying scripts
+        command: |
+          mkdir -p ~/.local/bin
+          cp ./scripts/* ~/.local/bin
+
+    - run:
+        name: Query resolver & ghc version
+        command: |
+          resolver "$(resolver $LTS)" > resolver.version
+          ghc-version $(cat resolver.version) >  ghc.version
+
+    - run:
+        name: Find all sub-projects
+        command: projects-summary > projects.summary
+
+    ##### Building library
+    - restore_cache:
+        keys:
+          - stack--nAz6PsL--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "projects.summary" }}--{{ checksum "package.yaml" }}--{{ checksum "stack.yaml" }}
+          - stack--nAz6PsL--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "projects.summary" }}--{{ checksum "package.yaml" }}
+          - stack--nAz6PsL--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "projects.summary" }}--
+          - stack--nAz6PsL--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--X
+
+    - run:
+        name: Stack setup
+        command: stack setup --resolver ${LTS}
+
+    - save_cache:
+        key:    stack--nAz6PsL--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--X
+        paths:  [~/.stack, ~/project/.stack-work]
+
+    - run:
+        name: Building dependencies
+        command: |
+          stack build --resolver ${LTS} --dependencies-only
+          stack build --resolver ${LTS} --dependencies-only --test --no-run-tests
+
+    - save_cache:
+        key:    stack--nAz6PsL--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "projects.summary" }}--{{ checksum "package.yaml" }}
+        paths:  [~/.stack, ~/project/.stack-work]
+
+    - run: stack build --resolver ${LTS} --test --no-run-tests
+
+    - save_cache:
+        key:    stack--nAz6PsL--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "projects.summary" }}--{{ checksum "package.yaml" }}--{{ checksum "stack.yaml" }}
+        paths:  [~/.stack, ~/project/.stack-work]
+
+    ##### Running tests
+    - run:
+        name: Running tests against latest on hackage
+        command: stack test --resolver ${LTS}
+
+cabalbuild: &cabalbuild
+  working_directory: ~/project
+
+  steps:
+    - checkout
+
+    - run:
+        name: Add GHC tools to PATH
+        command: |
+          echo "HOME=$HOME"
+          echo "BASH_ENV=$BASH_ENV"
+          echo "PATH=$PATH"
+          echo 'export PATH="$PATH:/opt/ghc/bin/"' >> $BASH_ENV
+
+    - run:
+        name: Copying scripts
+        command: |
+          mkdir -p ~/.local/bin
+          cp ./scripts/* ~/.local/bin
+
+    - run:
+        name: GHC version
+        command: |
+          echo "$GHC" > ghc.version
+          date +%Y-%m > month.version
+
+    - run:
+        name: Find all sub-projects
+        command: ./scripts/projects-summary > projects.summary
+
+    - run:
+        name: Generate cabal file
+        command: |
+          rm -f *.cabal
+          hpack
+
+    ##### Building library
+    - restore_cache:
+        keys:
+          - cabal--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "projects.summary" }}--extra
+          - cabal--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "projects.summary" }}--
+          - cabal--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "month.version"}}
+
+    - run:
+        name: Building build dependencies
+        command: |
+          ./scripts/mk-cabal-project > cabal.project
+          cabal update
+          cabal new-build --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j${CABAL_THREADS:-4} all
+          cabal new-build --enable-tests  --enable-benchmarks  --project-file="cabal.project" --dep -j${CABAL_THREADS:-4} all
+
+    - save_cache:
+        key:    cabal--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "projects.summary" }}--
+        paths:  [~/.cabal/packages, ~/.cabal/store]
+
+    - run:
+        name: Building project
+        command: |
+          cabal new-build --enable-tests --enable-benchmarks --project-file="cabal.project" -j${CABAL_THREADS:-4} all
+
+    - save_cache:
+        key:    cabal--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "projects.summary" }}--extra
+        paths:  [~/.cabal/packages, ~/.cabal/store]
+
+    - save_cache:
+        key:    cabal--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "month.version"}}
+        paths:  [~/.cabal/packages, ~/.cabal/store]
+
+    - run:
+        name: Running tests
+        command: |
+          if grep '^test-suite' *.cabal > /dev/null; then
+            cabal new-test --enable-tests --project-file="cabal.project" -j${CABAL_THREADS:-4} all
+          else
+            echo Not tests to run
+          fi
+
 version: 2.0
 jobs:
-  build:
-    working_directory: ~/project
+  ghc-8.4.3:
+    environment:
+      - GHC: "ghc8.4.3"
     docker:
-      - image: quay.io/haskell_works/stack-build-minimal:2018-01-29
+      - image: quay.io/haskell_works/ghc-8.4.3:18.04_2018-09-19
+    <<: *cabalbuild
+
+  ghc-8.2.2:
+    environment:
+      - GHC: "ghc8.2.2"
+    docker:
+      - image: quay.io/haskell_works/ghc-8.2.2:18.04_2018-09-19
+    <<: *cabalbuild
+
+  lts-12:
+    environment:
+      - LTS: "lts-12"
+    <<: *defaults
+
+  checked-builds:
+    docker:
+      - image: quay.io/haskell_works/ghc-8.4.3:18.04_2018-09-19
 
     steps:
       - checkout
 
-      ##### Building library
-      - restore_cache:
-          keys:
-            - dot-stack-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
-            - dot-stack-{{ checksum "stack.yaml" }}-build
-            - dot-stack-{{ checksum "stack.yaml" }}-setup
-
-      - restore_cache:
-          key: dot-stack-work-{{ checksum "stack.yaml" }}
+      - run:
+          name: Add GHC tools to PATH
+          command: |
+            echo "HOME=$HOME"
+            echo "BASH_ENV=$BASH_ENV"
+            echo "PATH=$PATH"
+            echo 'export PATH="$PATH:/opt/ghc/bin/"' >> $BASH_ENV
 
       - run:
-          name: Stack setup
-          command: stack setup
+          name: Copying scripts
+          command: |
+            mkdir -p ~/.local/bin
+            cp ./scripts/* ~/.local/bin
 
-      - save_cache:
-          key: dot-stack-{{ checksum "stack.yaml" }}-setup
-          paths:
-            - ~/.stack
+      - deploy:
+          command: |
+            hpack
+            if [ "$CIRCLE_PROJECT_USERNAME" == "arbor" ]; then
+              if [[ "$CIRCLE_BRANCH" == master ]]; then
+                when tag autotag
+              elif [[ "$CIRCLE_TAG" =~ v.* ]]; then
+                publish
+              fi
+            fi
+
+  release:
+    docker:
+      - image: quay.io/haskell_works/ghc-8.4.3:18.04_2018-09-19
+
+    steps:
+      - checkout
 
       - run:
-          name: Building dependencies
-          command: stack build --only-dependencies
+          name: Add GHC tools to PATH
+          command: |
+            echo "HOME=$HOME"
+            echo "BASH_ENV=$BASH_ENV"
+            echo "PATH=$PATH"
+            echo 'export PATH="$PATH:/opt/ghc/bin/"' >> $BASH_ENV
 
       - run:
-          name: Compiling
-          command: stack build --test --no-run-tests
+          name: Copying scripts
+          command: |
+            mkdir -p ~/.local/bin
+            cp ./scripts/* ~/.local/bin
 
-      - save_cache:
-          key: dot-stack-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
-          paths:
-            - ~/.stack
-      - save_cache:
-          key: dot-stack-{{ checksum "stack.yaml" }}-build
-          paths:
-            - ~/.stack
+      - deploy:
+          command: |
+            hpack
+            if [ "$CIRCLE_PROJECT_USERNAME" == "arbor" ]; then
+              if [[ "$CIRCLE_BRANCH" == master ]]; then
+                when tag autotag
+              elif [[ "$CIRCLE_TAG" =~ v.* ]]; then
+                publish
+              fi
+            fi
+  
+workflows:
+  version: 2
+  multiple-ghcs:
+    jobs:
+      - ghc-8.4.3
+      - ghc-8.2.2
+      - lts-12
+      - checked-builds:
+          requires:
+            - lts-12
+          filters:
+            branches:
+              only: master
 
-      - save_cache:
-          key: dot-stack-work-{{ checksum "stack.yaml" }}
-          paths: ~/project/.stack-work
-
-      ##### Running tests
-      - run:
-          name: Running tests against latest on hackage
-          command: stack test
+  tagged-release:
+    jobs:
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/app/App/Commands.hs
+++ b/app/App/Commands.hs
@@ -6,7 +6,7 @@ import App.Commands.Dump
 import App.Commands.EncodeFiles
 import App.Commands.ExtractFiles
 import App.Commands.ExtractSegments
-import Data.Monoid
+import Data.Monoid                  ((<>))
 import Options.Applicative
 
 globalOptions :: Parser (IO ())

--- a/app/App/Commands/Dump.hs
+++ b/app/App/Commands/Dump.hs
@@ -95,7 +95,7 @@ runDump opt = do
           Just (Known F.TimeMillis64LE) ->
             forM_ (LBS.chunkBy 8 (segment ^. the @"payload")) $ \bs -> do
               let w = G.runGet G.getInt64le (LBS.take 8 (bs <> LBS.replicate 8 0))
-              let t :: POSIXTime = (w `div` 1000) ^. from microseconds
+              let t :: POSIXTime = (w * 1000) ^. from microseconds
               liftIO $ IO.hPutStrLn hOut $ showTime (posixSecondsToUTCTime t) <> " (" <> show w <> " ms)"
           Just (Known F.TimeMicros64LE) ->
             forM_ (LBS.chunkBy 8 (segment ^. the @"payload")) $ \bs -> do

--- a/app/App/Commands/Dump.hs
+++ b/app/App/Commands/Dump.hs
@@ -18,7 +18,7 @@ import Data.Char                       (isPrint)
 import Data.Generics.Product.Any
 import Data.List
 import Data.Maybe
-import Data.Monoid
+import Data.Monoid                     ((<>))
 import Data.Thyme.Clock
 import Data.Thyme.Clock.POSIX          (POSIXTime)
 import Data.Thyme.Format               (formatTime)

--- a/app/App/Commands/EncodeFiles.hs
+++ b/app/App/Commands/EncodeFiles.hs
@@ -13,7 +13,7 @@ import Control.Monad
 import Control.Monad.IO.Class                    (liftIO)
 import Control.Monad.Trans.Resource              (MonadResource, runResourceT)
 import Data.Generics.Product.Any
-import Data.Monoid
+import Data.Monoid                               ((<>))
 import Options.Applicative
 
 import qualified Data.ByteString     as BS

--- a/app/App/Commands/ExtractFiles.hs
+++ b/app/App/Commands/ExtractFiles.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans.Resource   (MonadResource, runResourceT)
 import Data.Generics.Product.Any
 import Data.List
 import Data.Maybe
-import Data.Monoid
+import Data.Monoid                    ((<>))
 import Options.Applicative
 import System.Directory
 

--- a/app/App/Commands/ExtractSegments.hs
+++ b/app/App/Commands/ExtractSegments.hs
@@ -12,7 +12,7 @@ import Control.Monad
 import Control.Monad.IO.Class         (liftIO)
 import Control.Monad.Trans.Resource   (MonadResource, runResourceT)
 import Data.Generics.Product.Any
-import Data.Monoid
+import Data.Monoid                    ((<>))
 import Options.Applicative
 import System.Directory
 import Text.Printf

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,7 @@ module Main
 
 import App.Commands
 import Control.Monad
-import Data.Semigroup
+import Data.Semigroup      ((<>))
 import Options.Applicative
 
 import qualified System.IO as IO

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                asif
-version:             2.0.0
+version:             3.0.0
 github:              "packetloop/asif"
 license:             MIT
 category:            Services

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ dependencies:
 - exceptions
 - generic-lens
 - hw-bits
+- hw-ip
 - iproute
 - lens
 - old-locale
@@ -99,7 +100,6 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - asif
-    - arbor-ip
     - hspec
     - hedgehog
     - hw-hspec-hedgehog

--- a/project.sh
+++ b/project.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+STACK_FLAGS="
+  --flag bits-extra:bmi2
+  --flag hw-rankselect-base:bmi2
+  --flag hw-rankselect:bmi2
+"
+
+case $1 in
+  build)
+    stack build \
+      --test --no-run-tests --bench --no-run-benchmarks \
+      $STACK_FLAGS
+    ;;
+
+  test)
+    stack test \
+      $STACK_FLAGS
+    ;;
+
+  bench)
+    stack bench \
+      $STACK_FLAGS
+    ;;
+
+  repl)
+    stack repl \
+      $STACK_FLAGS
+    ;;
+esac

--- a/scripts/autotag
+++ b/scripts/autotag
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+if [ "$_system_type" == "Darwin" ]; then
+  sed () {
+    gsed "$@"
+  }
+fi
+
+_repo_name=$(basename `git rev-parse --show-toplevel`)
+
+_version="$(cat package.yaml | grep '^version:' | head -n 1 | cut -d : -f 2 | xargs)"
+
+_branch=$(git rev-parse --abbrev-ref HEAD)
+_branch_prefix=${_branch%-branch}
+
+if [[ $(git ls-remote origin "refs/tags/v$_version") ]]; then
+  echo "The tag v$_version already exists.  Will not tag"
+  exit 0
+fi
+
+_commit=$(git rev-parse --verify HEAD)
+
+_release_data=$(cat <<EOF
+{
+  "tag_name": "v$_version",
+  "target_commitish": "$_commit",
+  "name": "v$_version",
+  "body": "New release",
+  "draft": false,
+  "prerelease": false
+}
+EOF
+)
+
+echo "Creating release v$_version from commit $_commit in branch $_branch"
+
+curl -H "Authorization: token $GITHUB_TOKEN" \
+  -X POST https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/releases \
+  --data "$_release_data"

--- a/scripts/bintray-credentials.sh
+++ b/scripts/bintray-credentials.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+DIR=$HOME/.bintray
+
+mkdir $DIR
+cat <<EOF >$DIR/.credentials
+realm = Bintray API Realm
+host = api.bintray.com
+user = $BINTRAY_USER
+password = $BINTRAY_API_KEY
+EOF
+
+cat <<EOF >$DIR/.readonly
+realm = Bintray
+host = dl.bintray.com
+user = $BINTRAY_USER
+password = $BINTRAY_API_KEY
+EOF
+
+echo "Created ${DIR} files for user ${BINTRAY_USER}"
+ls -la $DIR

--- a/scripts/check-env-variables.sh
+++ b/scripts/check-env-variables.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+declare -a vars=(\
+"BINTRAY_USER your bintray user account" \
+"BINTRAY_API_KEY your bintray api key" \
+"BINTRAY_EMAIL required to login to the bintray docker repository" \
+)
+
+for var in "${vars[@]}"
+do
+  v=${var%% *}
+  if [ "${!v-x}" = "x" -a "${!v-y}" = "y" ]; then
+    printf 'NOT FOUND: $%s\n' "$var"
+    _not_found=true
+  else
+    printf 'found: $%s\n' "$v"
+  fi
+done
+
+[ -z "${_not_found}" ] && exit 0
+
+echo "*****************************"
+echo "MISSING ENVIRONMENT VARIABLES"
+echo "*****************************"
+exit 1

--- a/scripts/fetch
+++ b/scripts/fetch
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+stack query
+
+cabal update
+
+mkdir -p deps
+
+_project="$(cat package.yaml | grep '^name:' | head -n 1 | cut -d : -f 2 | xargs)"
+
+direct_deps() {
+  cat ../package.yaml | grep '# \+use-latest-in-ci' | cut -d '#' -f 1 | sed 's|^ *- *||g' | sed 's| .*$||g'
+}
+
+pushd deps > /dev/null
+
+cp ../$_project.cabal ./
+
+projects() {
+  for x in $(direct_deps | sort | uniq); do
+    cabal install $x --dry-run | grep -v "^${_project}-[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+$" | tail -n 1
+  done
+}
+
+if grep '^ *# extra-deps-insertion-point' ../stack.yaml; then
+  _indent="$(grep '^ *# extra-deps-insertion-point' ../stack.yaml | head -n 1 | cut -d '#' -f 1 | tr -d '\n')"
+  projects | sort | uniq | sed "s|^|$_indent- |g" > stack-b.yaml
+  grep '^ *# extra-deps-insertion-point' -B 1000 ../stack.yaml                                              > stack-a.yaml
+  grep '^ *# extra-deps-insertion-point' -A 1000 ../stack.yaml | grep -v '^ *# extra-deps-insertion-point'  > stack-c.yaml
+else
+  cp ../stack.yaml stack-a.yaml
+  rm -f stack-b.yaml; touch stack-b.yaml
+  echo > stack-c.yaml
+fi
+
+cat stack-a.yaml stack-b.yaml stack-c.yaml > ../stack-ci.yaml
+
+popd > /dev/null

--- a/scripts/ghc-version
+++ b/scripts/ghc-version
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+_resolver="$1"
+
+download_snapshot () {
+  local _resolver="$1"
+
+  if [[ $_resolver == lts-* ]]; then
+    curl -s https://raw.githubusercontent.com/fpco/lts-haskell/master/${_resolver}.yaml \
+      | grep 'ghc:' | head -n 1 | cut -d ':' -f 2 | xargs echo -n 2> /dev/null
+  elif [[ $_resolver == nightly-* ]]; then
+    curl -s https://raw.githubusercontent.com/fpco/stackage-nightly/master/${_resolver}.yaml \
+      | grep 'ghc:' | head -n 1 | cut -d ':' -f 2 | xargs echo -n 2> /dev/null
+  fi
+}
+
+download_snapshot "${_resolver}"

--- a/scripts/mk-cabal-project
+++ b/scripts/mk-cabal-project
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cat <<EOF
+packages: "."
+EOF

--- a/scripts/package-name
+++ b/scripts/package-name
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cat package.yaml | grep '^name:' | head -n 1 | cut -d : -f 2 | xargs

--- a/scripts/projects-summary
+++ b/scripts/projects-summary
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+find . -name "package.yaml" -o -name "*.cabal" | grep -v '.stack-work/' | sort | xargs grep '^' | grep -v ':version:'

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+if [ "$_system_type" == "Darwin" ]; then
+  sed () {
+    gsed "$@"
+  }
+fi
+
+if [ "$HACKAGE_USER" == "" ] || [ "$HACKAGE_PASS" == "" ]; then
+  echo "Must supply credentials"
+  exit 1
+fi
+
+_repo_name=$(basename `git rev-parse --show-toplevel`)
+_project="$(cat package.yaml | grep '^name:' | head -n 1 | cut -d : -f 2 | xargs)"
+_version="$(cat package.yaml | grep '^version:' | head -n 1 | cut -d : -f 2 | xargs)"
+
+if [ "v$_version" != "$CIRCLE_TAG" ]; then
+  echo "Tag mismatch: "v$_version != $CIRCLE_TAG""
+  exit 1
+fi
+
+cabal configure
+
+cabal sdist
+
+if [ "$ALLOW_UPLOAD" != "" ]; then
+  cabal upload \
+    --username=$HACKAGE_USER \
+    --password=$HACKAGE_PASS \
+    "dist/${_project}-${_version}.tar.gz" \
+    ${PUBLISH+--publish}
+fi

--- a/scripts/resolver
+++ b/scripts/resolver
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [ $# -eq 0 ]; then
+  cat stack.yaml | grep '^resolver:' | cut -d : -f 2 | xargs echo -n
+elif [ $# -eq 1 ]; then
+  _resolver_alias="$1"
+  _resolver="$(curl -I -Ls -w %{url_effective} -o /dev/null https://www.stackage.org/${_resolver_alias} | cut -d / -f 4)"
+  echo -n "${_resolver}"
+else
+  echo "Invalid arguments"
+  exit 1
+fi

--- a/scripts/setup-cred
+++ b/scripts/setup-cred
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cred=~/.stack/upload/credentials.json  
+if [ ! -f "${cred}" ]; then  
+    if [ ! -e ~/.stack/upload ]; then
+    mkdir -p ~/.stack/upload
+    fi
+    echo "{\"username\":\"${HACKAGE_USER}\",\"password\":\"${HACKAGE_PASS}\"}" > ${cred}
+fi

--- a/scripts/up
+++ b/scripts/up
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+if [ "$_system_type" == "Darwin" ]; then
+  sed () {
+    gsed "$@"
+  }
+fi
+
+_repo_name=$(basename `git rev-parse --show-toplevel`)
+
+_version=$(
+  cat $_repo_name.cabal | grep '^version:' | head | cut -d ':' -f 2 | xargs
+)
+
+_major=$(
+  echo $_version | sed 's|^\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)|\1|g'
+)
+
+_minor=$(
+  echo $_version | sed 's|^\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)|\2|g'
+)
+
+_point=$(
+  echo $_version | sed 's|^\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)|\3|g'
+)
+
+_patch=$(
+  echo $_version | sed 's|^\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)|\4|g'
+)
+
+
+case $1 in
+major)
+  _new_version="$(($_major + 1)).0.0.0"
+  _new_branch="$(($_major + 1))"
+  ;;
+minor)
+  _new_version="$_major.$(($_minor + 1)).0.0"
+  ;;
+point)
+  _new_version="$_major.$_minor.$(($_point + 1)).0"
+  ;;
+patch)
+  _new_version="$_major.$_minor.$_point.$(($_patch + 1))"
+  ;;
+*)
+  echo "./scripts/up (major|minor|point|patch)"
+  exit 1
+esac
+
+sed "s|^\(version:\s*\)\([0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+\)$|\1$_new_version|g" -i $_repo_name.cabal
+
+echo "Cabal project version upgrade to $_new_version"
+echo ""
+echo "Please review and run the following commands:"
+echo ""
+
+if [ "$_new_branch" != "" ]; then
+  echo "  git checkout -b ${_new_branch}-branch"
+fi
+
+echo "  git add $_repo_name.cabal"
+echo "  git commit -m 'New version $_new_version'"
+
+if [ "$_new_branch" != "" ]; then
+  echo "  git push --set-upstream origin ${_new_branch}-branch"
+else
+  echo "  git push origin"
+fi
+
+echo ""

--- a/scripts/when
+++ b/scripts/when
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+_expected_stage="$1"
+
+if [ "$BUILD_STAGES" == "" ]; then
+  BUILD_STAGES=all
+fi
+
+for stage in $BUILD_STAGES; do
+  if [ "$stage" == "$_expected_stage" ] || [ "$stage" == "all" ]; then
+    shift 1
+    "$@"
+
+    break
+  fi
+done

--- a/src/Arbor/File/Format/Asif/ByIndex.hs
+++ b/src/Arbor/File/Format/Asif/ByIndex.hs
@@ -7,7 +7,7 @@ module Arbor.File.Format.Asif.ByIndex
   ( ByIndex(..)
   ) where
 
-import Data.Monoid
+import Data.Monoid ((<>))
 
 import qualified Data.Semigroup as S
 
@@ -22,8 +22,8 @@ instance (Monoid a, S.Semigroup a) => Monoid (ByIndex a) where
   mappend = (S.<>)
   mempty = ByIndex []
 
-appendByIndex :: (Monoid a, S.Semigroup a) => [a] -> [a] -> [a]
-appendByIndex (a:as) (b:bs) = (a <> b):appendByIndex as bs
-appendByIndex (a:as) bs     =  a      :appendByIndex as bs
-appendByIndex    as  (b:bs) =       b :appendByIndex as bs
+appendByIndex :: Monoid a => [a] -> [a] -> [a]
+appendByIndex (a:as) (b:bs) = (a `mappend` b):appendByIndex as bs
+appendByIndex (a:as) bs     =  a             :appendByIndex as bs
+appendByIndex    as  (b:bs) =              b :appendByIndex as bs
 appendByIndex    []     []  = []

--- a/src/Arbor/File/Format/Asif/ByteString/Builder.hs
+++ b/src/Arbor/File/Format/Asif/ByteString/Builder.hs
@@ -19,7 +19,7 @@ import Data.ByteString.Builder
 import Data.Generics.Product.Any
 import Data.Int
 import Data.Maybe
-import Data.Monoid
+import Data.Monoid                     ((<>))
 import Data.String
 import Data.Thyme.Clock
 import Data.Thyme.Clock.POSIX          (POSIXTime, getPOSIXTime)

--- a/src/Arbor/File/Format/Asif/Get.hs
+++ b/src/Arbor/File/Format/Asif/Get.hs
@@ -4,7 +4,7 @@ import Arbor.File.Format.Asif.ByteString.Builder
 import Control.Lens
 import Control.Monad
 import Data.Binary.Get
-import Data.Monoid
+import Data.Monoid                               ((<>))
 import Data.Text                                 (Text)
 import Data.Thyme.Clock                          (microseconds)
 import Data.Thyme.Clock.POSIX                    (POSIXTime)

--- a/src/Arbor/File/Format/Asif/Segment.hs
+++ b/src/Arbor/File/Format/Asif/Segment.hs
@@ -17,7 +17,7 @@ import Control.Monad
 import Data.Binary.Get
 import Data.Generics.Product.Any
 import Data.Maybe
-import Data.Monoid
+import Data.Monoid                    ((<>))
 import Data.Text                      (Text, pack)
 
 import qualified Arbor.File.Format.Asif.Extract as E

--- a/src/Arbor/File/Format/Asif/Type.hs
+++ b/src/Arbor/File/Format/Asif/Type.hs
@@ -5,7 +5,7 @@ module Arbor.File.Format.Asif.Type where
 import Arbor.File.Format.Asif.Format   (Format)
 import Arbor.File.Format.Asif.Maybe
 import Arbor.File.Format.Asif.Whatever
-import Data.Semigroup
+import Data.Semigroup                  (Semigroup, (<>))
 import Data.Text                       (Text)
 import Data.Thyme.Clock.POSIX          (POSIXTime)
 import GHC.Generics

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,15 +1,12 @@
-resolver: lts-11.17
+resolver: lts-12.10
 
 packages:
 - .
-- location:
-    git: git@github.com:packetloop/arbor-ip.git
-    commit: 9cea5e3c5e3eeaf767f97749b127a7495604f845
-  extra-dep: true
 
 extra-deps:
 - hw-fingertree-strict-0.1.0.3
 - hw-hspec-hedgehog-0.1.0.4
+- hw-ip-0.2.1.0
 - lazy-csv-0.5.1
 - temporary-resourcet-0.1.0.0
 - thyme-0.3.5.5

--- a/test/Gen/Feed.hs
+++ b/test/Gen/Feed.hs
@@ -5,22 +5,17 @@ module Gen.Feed
   , ordBy
   ) where
 
-import Arbor.Network.Ip
 import Data.Word
+import HaskellWorks.Data.Network.Ip
+import HaskellWorks.Data.Network.Ip.Internal
 import Hedgehog
 
 import qualified Hedgehog.Gen   as G
 import qualified Hedgehog.Range as R
 
-ipv4 :: MonadGen m => Word8 -> Word8 -> m IPv4
-ipv4 start stop = do
-  o1 <- w8
-  o2 <- w8
-  o3 <- w8
-  o4 <- w8
-  return $ ipFromOctets o1 o2 o3 o4
-  where
-    w8 = G.word8 (R.linear start stop)
+ipv4 :: MonadGen m => Word8 -> Word8 -> m Ipv4Address
+ipv4 start stop = Ipv4Address <$> (fourOctetsToWord32 <$> w8 <*> w8 <*> w8 <*> w8)
+  where w8 = G.word8 (R.linear start stop)
 
 feedElemIp :: MonadGen m => Range Word32 -> m Word32
 feedElemIp = G.word32


### PR DESCRIPTION
Switching to use `hw-ip` because that is already open-source from `arbor-ip` which isn't (yet).  Using a close source library from an open-source one is bad because people outside our organisation won't be able to build it and it won't be possible for us to publish to hackage.