### PR TITLE
Add Ipv6 type that can have Ipv4s in them

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ dependencies:
 - hw-ip
 - iproute
 - lens
+- network
 - old-locale
 - resourcet
 - temporary-resourcet

--- a/src/Arbor/File/Format/Asif/Data/Ip.hs
+++ b/src/Arbor/File/Format/Asif/Data/Ip.hs
@@ -1,8 +1,13 @@
 module Arbor.File.Format.Asif.Data.Ip
   ( stringToIpv4
+  , stringToIpv6
   , ipv4ToString
+  , ipv6ToString
   , word32ToIpv4
+  , word32x4ToIpv6
   , ipv4ToWord32
+  , ipv6ToWord32x4
+  , ipv4ToIpv6
   ) where
 
 import Arbor.File.Format.Asif.Data.Read
@@ -16,11 +21,26 @@ stringToIpv4 str = if '.' `elem` str
   then readMaybe str
   else word32ToIpv4 <$> stringToAnyDigits str
 
+stringToIpv6 :: String -> Maybe IPv6
+stringToIpv6 = readMaybe
+
 ipv4ToString :: IPv4 -> String
 ipv4ToString = show
+
+ipv6ToString :: IPv6 -> String
+ipv6ToString = show
 
 word32ToIpv4 :: Word32 -> IPv4
 word32ToIpv4 = fromHostAddress . toBE32
 
+word32x4ToIpv6 :: (Word32, Word32, Word32, Word32) -> IPv6
+word32x4ToIpv6 = fromHostAddress6
+
 ipv4ToWord32 :: IPv4 -> Word32
 ipv4ToWord32 = fromBE32 . toHostAddress
+
+ipv6ToWord32x4 :: IPv6 -> (Word32, Word32, Word32, Word32)
+ipv6ToWord32x4 = toHostAddress6
+
+ipv4ToIpv6 :: IPv4 -> IPv6
+ipv4ToIpv6 = ipv4ToIPv6

--- a/src/Arbor/File/Format/Asif/Format.hs
+++ b/src/Arbor/File/Format/Asif/Format.hs
@@ -13,6 +13,7 @@ data Format
   | Int32LE
   | Int64LE
   | Ipv4
+  | Ipv6
   | Repeat Word Format
   | StringZ
   | Text


### PR DESCRIPTION
A new `Format` type called `Ipv6` with associated pretty printing.

An `IPv6` can hold an `IPv4` if the first two words are zeroes and the third is `0x0000FFFF`. The last word is the network-oriented IPv4 address. So when pretty printing the new format, we are making sure we can still print these embedded ones.

e.g.

```
==== [2] .asif/formats ====
Ipv6
==== [3] ips ====
54.233.128.0                                                    (921272320)
176.34.64.0                                                     (2955034624)
191.233.8.0                                                     (3219720192)
191.236.64.0                                                    (3219931136)
199.223.236.0                                                   (3353340928)
208.68.108.0                                                    (3494145024)
fe80::                                                          ((4269801472,0,0,0))
```