### PR TITLE
Add support to dump without specified segments

### DIFF
--- a/app/App/Commands/DumpOnly.hs
+++ b/app/App/Commands/DumpOnly.hs
@@ -7,7 +7,7 @@ module App.Commands.DumpOnly
   ( commandDumpOnly
   ) where
 
-import App.Commands.Options.Type
+import App.Commands.Options.Type      (DumpOnlyOptions (DumpOnlyOptions))
 import App.Dump
 import Arbor.File.Format.Asif.IO
 import Arbor.File.Format.Asif.Segment

--- a/app/App/Commands/EncodeFiles.hs
+++ b/app/App/Commands/EncodeFiles.hs
@@ -4,7 +4,7 @@
 
 module App.Commands.EncodeFiles where
 
-import App.Commands.Options.Type
+import App.Commands.Options.Type                 (EncodeFilesOptions (EncodeFilesOptions))
 import Arbor.File.Format.Asif.ByteString.Builder
 import Arbor.File.Format.Asif.IO
 import Conduit

--- a/app/App/Commands/ExtractFiles.hs
+++ b/app/App/Commands/ExtractFiles.hs
@@ -4,7 +4,7 @@
 
 module App.Commands.ExtractFiles where
 
-import App.Commands.Options.Type
+import App.Commands.Options.Type      (ExtractFilesOptions (ExtractFilesOptions))
 import Arbor.File.Format.Asif.IO
 import Arbor.File.Format.Asif.Segment
 import Control.Lens

--- a/app/App/Commands/ExtractSegments.hs
+++ b/app/App/Commands/ExtractSegments.hs
@@ -4,7 +4,7 @@
 
 module App.Commands.ExtractSegments where
 
-import App.Commands.Options.Type
+import App.Commands.Options.Type      (ExtractSegmentsOptions (ExtractSegmentsOptions))
 import Arbor.File.Format.Asif.IO
 import Arbor.File.Format.Asif.Segment
 import Control.Lens

--- a/app/App/Commands/Options/Type.hs
+++ b/app/App/Commands/Options/Type.hs
@@ -22,8 +22,10 @@ data ExtractSegmentsOptions = ExtractSegmentsOptions
   } deriving (Eq, Show, Generic)
 
 data DumpOptions = DumpOptions
-  { source :: FilePath
-  , target :: FilePath
+  { source           :: FilePath
+  , target           :: FilePath
+  , withoutSegments  :: [Int]
+  , withoutFilenames :: [FilePath]
   } deriving (Eq, Show, Generic)
 
 data DumpOnlyOptions = DumpOnlyOptions


### PR DESCRIPTION
```
$ asif dump --source ./cloud-address-feed.asif --without-segment 3 --without-segment 4 --without-segment 5 --without-segment 6
==== [0] .asif/filenames ====
.asif/filenames
.asif/createtimes
.asif/formats
cidr/starts
cidr/stops
cloud-providers
bitmap/akamai
==== [1] .asif/createtimes ====
1970-01-01T00:00:00 UTC (0 µs)
1970-01-01T00:00:00 UTC (0 µs)
1970-01-01T00:00:00 UTC (0 µs)
1970-01-01T00:00:00 UTC (0 µs)
1970-01-01T00:00:00 UTC (0 µs)
1970-01-01T00:00:00 UTC (0 µs)
1970-01-01T00:00:00 UTC (0 µs)
==== [2] .asif/formats ====
StringZ
TimeMicros64LE
StringZ
Ipv6
Ipv6
StringZ
Bitmap
```