### PR TITLE
we went from 8 to 16 bytes for magic length

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Library for creating and querying segmented feeds.
 |Segmented OSI Model |
 +--------------------+
 
- magic, where XXXX is a feed type
-+---------------------+-------------+
-| "seg:XXXX" [char:8] | ver: uint64 |
-+---------------------+-------------+
+ magic, where XXXX is a feed type (0-12 chars)
++----------------------+
+| "seg:XXXX" [char:16] |
++----------------------+
 
 c -- countries
 a -- asns

--- a/src/Arbor/File/Format/Asif/ByteString/Builder.hs
+++ b/src/Arbor/File/Format/Asif/ByteString/Builder.hs
@@ -44,7 +44,7 @@ magicPrefix :: IsString a => a
 magicPrefix = "seg:"
 
 -- magic file identifier for segmented gan feeds.
--- 7 characters. the 8th is meant to be filled in based on feed.
+-- 16 characters. the last 12 are meant to be filled in based on feed.
 magicString :: String -> LC8.ByteString
 magicString s = if LBS.length truncatedMagic < LBS.length rawMagic
   then truncatedMagic


### PR DESCRIPTION
Adjust comments and README to match a design decision a long time ago. magic length is 16 bytes because the initial `ver` field never materialised and we want to align on 64-bit boundaries.